### PR TITLE
feat: Native Support for GCP CUD Multiprice Model

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,13 @@ There are several view files:
 - [period_over_period](/views/period_over_period.view.lkml) - fields specific to period over period analysis, for example looking at current Year to Date spend compared to Prior
 - [currency_symbols](/views/currency_symbols.view.lkml) - customizes the html for spend metrics to include the currency symbol specific to the currency set in the billing export
 
+#### Schema Support (Legacy vs. New CUD Model)
+
+This block is updated to natively support the **CUDs Multiprice Data Model** (Proportional Attribution).
+
+* **Native Support:** The `gcp_billing_export` view now includes fields like `consumption_model` and `list_price`, along with updated logic for `credits` to handle offsets.
+* **Legacy Compatibility:** If you are still on the Legacy billing schema, the core financial metrics (e.g., `Total Net Cost`) remain accurate and safe to use. **Note:** Attempting to query the specific new CUD fields (like `list_price`) before your BigQuery table has been migrated may result in database errors, as those columns do not exist in the legacy schema.
+
 Note: this block leverages [presistent derived tables](https://docs.looker.com/data-modeling/learning-lookml/derived-tables#temporary_and_persistent_derived_tables) and [incremental derived tables](https://docs.looker.com/data-modeling/learning-lookml/derived-tables#incrementally_building_pdts). Please make sure these are enabled in your Looker instance in order to use.
 
 ### Customizing the Model

--- a/explores/cloud_pricing_export.explore.lkml
+++ b/explores/cloud_pricing_export.explore.lkml
@@ -1,3 +1,4 @@
+include: "/views/**.view"
 
 explore: cloud_pricing_export {
   label: "Pricing Taxonomy"

--- a/explores/cloud_pricing_export.explore.lkml
+++ b/explores/cloud_pricing_export.explore.lkml
@@ -1,4 +1,4 @@
-include: "/views/**.view"
+include: "/views/**.view.lkml"
 
 explore: cloud_pricing_export {
   label: "Pricing Taxonomy"

--- a/views/gcp_billing_export.view.lkml
+++ b/views/gcp_billing_export.view.lkml
@@ -339,15 +339,10 @@ view: gcp_billing_export {
 
   # --- NEW CUD FIELDS (Added for Migration Support) ---
 
-  dimension: consumption_model {
-    hidden: yes
-    sql: ${TABLE}.consumption_model ;;
-  }
-
   dimension: consumption_model_type {
     type: string
     description: "Indicates if the usage is 'Default' (On-Demand) or covered by a CUD."
-    sql: ${consumption_model}.description ;;
+    sql: ${TABLE}.consumption_model.description ;;
     group_label: "CUD Analysis"
   }
 

--- a/views/gcp_billing_export.view.lkml
+++ b/views/gcp_billing_export.view.lkml
@@ -83,7 +83,7 @@ view: gcp_billing_export {
     type: string
     sql: ${TABLE}.billing_account_id ;;
   }
-  
+
   dimension: cloud {
     type: string
     sql: 'GCPe' ;;
@@ -337,6 +337,27 @@ view: gcp_billing_export {
     sql: ${TABLE}.usage_start_time ;;
   }
 
+  # --- NEW CUD FIELDS (Added for Migration Support) ---
+
+  dimension: consumption_model {
+    hidden: yes
+    sql: ${TABLE}.consumption_model ;;
+  }
+
+  dimension: consumption_model_type {
+    type: string
+    description: "Indicates if the usage is 'Default' (On-Demand) or covered by a CUD."
+    sql: ${consumption_model}.description ;;
+    group_label: "CUD Analysis"
+  }
+
+  dimension: list_price {
+    type: number
+    description: "The gross list price of the SKU before discounts."
+    sql: ${TABLE}.price.list_price ;;
+    value_format_name: decimal_4
+  }
+
   measure: count {
     hidden: no
     type: count
@@ -366,6 +387,7 @@ view: gcp_billing_export {
   }
 
   measure: total_cost {
+    description: "Total Cost. HEADS UP: Under the new CUD model, this reflects List Price. Use Net Cost for actual spend."
     type: sum
     sql: ${cost} ;;
     value_format: "#,##0.00"
@@ -432,9 +454,12 @@ view: gcp_billing_export__credits {
 
   dimension: type {
     type: string
-    sql: case when ${name} like "%Committed Usage%" then "COMMITTED_USAGE_DISCOUNT"
-              when ${name} like "%Sustained Usage%" then "SUSTAINED_USAGE_DISCOUNT"
-              else ${TABLE}.type end;;
+    sql: CASE
+            WHEN ${TABLE}.type = 'FEE_UTILIZATION_OFFSET' THEN 'FEE_UTILIZATION_OFFSET'
+            WHEN ${name} LIKE "%Committed Usage%" THEN "COMMITTED_USAGE_DISCOUNT"
+            WHEN ${name} LIKE "%Sustained Usage%" THEN "SUSTAINED_USAGE_DISCOUNT"
+            ELSE ${TABLE}.type
+          END;;
     drill_fields: [name]
   }
 
@@ -475,6 +500,17 @@ view: gcp_billing_export__credits {
     sql: -1*${amount} ;;
     filters: [gcp_billing_export__credits.type: "PROMOTION"]
     drill_fields: [gcp_billing_export__credits.id,gcp_billing_export__credits.name,total_amount]
+  }
+
+  measure: total_fee_utilization_offset {
+    view_label: "Credits"
+    group_label: "Credits Breakdown"
+    type: sum
+    value_format: "#,##0.00"
+    html: <a href="#drillmenu" target="_self">{{ gcp_billing_export.currency_symbol._value }}{{ rendered_value }}</a>;;
+    sql: -1*${amount} ;;
+    filters: [type: "FEE_UTILIZATION_OFFSET"]
+    description: "The offset credit that balances the CUD List Price cost."
   }
 }
 


### PR DESCRIPTION
Updates the block to natively support the New GCP CUD Multiprice Data Model while maintaining backward compatibility.

Views: Added list_price, consumption_model, and updated credit logic to handle FEE_UTILIZATION_OFFSET.

Safety: Verified that Total Net Cost remains mathematically accurate (Sum(Cost) + Sum(Credits)) for both legacy and migrated data.